### PR TITLE
Fix website URL

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+gitahead.com


### PR DESCRIPTION
http://gitahead.com/ redirects to https://gitahead.github.io/gitahead.com/

This CNAME file will prevent that.